### PR TITLE
make open-vm-tools option work in guest monitoring

### DIFF
--- a/modules/vm_runtime_info.pm
+++ b/modules/vm_runtime_info.pm
@@ -261,8 +261,16 @@ sub vm_runtime_info
                       }
                    if ($vm_view->guest->toolsVersionStatus eq "guestToolsUnmanaged")
                       {
-                      $tools_out = "VMware Tools are installed and running, but not managed by VMWare. ";
-                      $actual_state = 2;
+                      if (defined($openvmtools))
+                         {
+                         $tools_out = "VMware Tools are installed and running, but not managed by VMWare. ";
+                         $actual_state = 0;
+                         }
+                      else
+                         {
+                         $tools_out = "VMware Tools are installed and running, but not managed by VMWare. ";
+                         $actual_state = 1;
+                         }
                       }
                    }
                 else


### PR DESCRIPTION
- like in dc_runtime_info.pm: to signalize that Open VM Tools are used when "--open-vm-tools" option is defined
- reducing alert state level from CRITICAL to WARNING